### PR TITLE
Update Test-CSOnlineUserVoiceRouting.ps1

### DIFF
--- a/Test-CSOnlineUserVoiceRouting.ps1
+++ b/Test-CSOnlineUserVoiceRouting.ps1
@@ -100,7 +100,7 @@ if ($UserReturned) {
     # Get effective dial plan for user, then test it and return normalised number (if needed) along with the matched rule
     Write-Host "`nGetting Effective Tenant Dial Plan for $user and translating number..."
     $EffectiveDialPlan = Get-CsEffectiveTenantDialPlan -Identity $user
-    $NormalisedResult = $EffectiveDialPlan | Test-CsEffectiveTenantDialPlan -DialedNumber $DialedNumber
+    $NormalisedResult = Test-CsEffectiveTenantDialPlan -DialedNumber $DialedNumber
 
     if ($NormalisedResult.TranslatedNumber) {
 


### PR DESCRIPTION
changed $NormalisedResult to works with teams

Original version returns:

Line |
 103 |  … eDialPlan | Test-CsEffectiveTenantDialPlan -DialedNumber $DialedNumbe …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The input object cannot be bound to any parameters for the command either because the command does not take pipeline input or the input and its properties do not match any of the parameters that
     | take pipeline input.
Test-CsEffectiveTenantDialPlan:Test-CSOnlineUserVoiceRouting.ps1:103
Line |
 103 |      $NormalisedResult = $EffectiveDialPlan | Test-CsEffectiveTenantDi …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Object reference not set to an instance of an object.
