### PR TITLE
Show Voice Routing Policy That Has Been Assigned via Group Policy Assignment

### DIFF
--- a/Test-CSOnlineUserVoiceRouting.ps1
+++ b/Test-CSOnlineUserVoiceRouting.ps1
@@ -119,7 +119,7 @@ if ($UserReturned) {
     }
     # Get the Online Voice Routing Policy assigned to the user
     Write-Host "`nGetting assigned Online Voice Routing Policy for $User..."
-    [string]$UserOnlineVoiceRoutingPolicy = ($UserReturned).OnlineVoiceRoutingPolicy
+    [string]$UserOnlineVoiceRoutingPolicy = (Get-CsUserPolicyAssignment -Identity $User -PolicyType OnlineVoiceRoutingPolicy).PolicyName
 
     if ($UserOnlineVoiceRoutingPolicy) {
 


### PR DESCRIPTION
Update Voice Routing Policy section to account for a Voice Routing Policy that is assigned by Group Policy Assignment.